### PR TITLE
Add show confimation dialogs with custom widget

### DIFF
--- a/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
+++ b/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
@@ -13,65 +13,32 @@ UAsyncAction_ShowConfirmation::UAsyncAction_ShowConfirmation( const FObjectIniti
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationYesNo( UObject * InWorldContextObject, FText Title, FText Message )
 {
-    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
-    Action->WorldContextObject = InWorldContextObject;
-    Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationYesNo( Title, Message );
-    Action->RegisterWithGameInstance( InWorldContextObject );
-
-    return Action;
+    return CreateAction( InWorldContextObject, UCommonGameDialogDescriptor::CreateConfirmationYesNo( Title, Message ) );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetYesNo( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
 {
-    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
-    action->WorldContextObject = in_world_context_object;
-    action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationYesNo( title, message );
-    action->RegisterWithGameInstance( in_world_context_object );
-    action->CustomDialogWidget = custom_dialog_widget;
-
-    return action;
+    return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationYesNo( title, message ), custom_dialog_widget );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationOkCancel( UObject * InWorldContextObject, FText Title, FText Message )
 {
-    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
-    Action->WorldContextObject = InWorldContextObject;
-    Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationOkCancel( Title, Message );
-    Action->RegisterWithGameInstance( InWorldContextObject );
-
-    return Action;
+    return CreateAction( InWorldContextObject, UCommonGameDialogDescriptor::CreateConfirmationOkCancel( Title, Message ) );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetOkCancel( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
 {
-    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
-    action->WorldContextObject = in_world_context_object;
-    action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationOkCancel( title, message );
-    action->RegisterWithGameInstance( in_world_context_object );
-    action->CustomDialogWidget = custom_dialog_widget;
-
-    return action;
+    return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationOkCancel( title, message ), custom_dialog_widget );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationCustom( UObject * InWorldContextObject, UCommonGameDialogDescriptor * Descriptor )
 {
-    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
-    Action->WorldContextObject = InWorldContextObject;
-    Action->Descriptor = Descriptor;
-    Action->RegisterWithGameInstance( InWorldContextObject );
-
-    return Action;
+    return CreateAction( InWorldContextObject, Descriptor );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetCustom( UObject * in_world_context_object, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
 {
-    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
-    action->WorldContextObject = in_world_context_object;
-    action->Descriptor = descriptor;
-    action->RegisterWithGameInstance( in_world_context_object );
-    action->CustomDialogWidget = custom_dialog_widget;
-
-    return action;
+    return CreateAction( in_world_context_object, descriptor, custom_dialog_widget );
 }
 
 void UAsyncAction_ShowConfirmation::Activate()
@@ -116,4 +83,16 @@ void UAsyncAction_ShowConfirmation::HandleConfirmationResult( ECommonMessagingRe
     OnResult.Broadcast( ConfirmationResult );
 
     SetReadyToDestroy();
+}
+
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::CreateAction( UObject * in_world_context, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
+{
+    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
+    action->WorldContextObject = in_world_context;
+    action->Descriptor = descriptor;
+    action->CustomDialogWidget = custom_dialog_widget;
+
+    action->RegisterWithGameInstance( in_world_context );
+
+    return action;
 }

--- a/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
+++ b/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
@@ -1,19 +1,18 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #include "Actions/AsyncAction_ShowConfirmation.h"
 
-#include "Engine/GameInstance.h"
 #include "Messaging/CommonGameDialog.h"
 #include "Messaging/CommonMessagingSubsystem.h"
 
-UAsyncAction_ShowConfirmation::UAsyncAction_ShowConfirmation( const FObjectInitializer & ObjectInitializer ) :
-    Super( ObjectInitializer )
+#include <Engine/GameInstance.h>
+
+UAsyncAction_ShowConfirmation::UAsyncAction_ShowConfirmation( const FObjectInitializer & object_initializer ) :
+    Super( object_initializer )
 {
 }
 
-UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationYesNo( UObject * InWorldContextObject, FText Title, FText Message )
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationYesNo( UObject * in_world_context_object, FText title, FText message )
 {
-    return CreateAction( InWorldContextObject, UCommonGameDialogDescriptor::CreateConfirmationYesNo( Title, Message ) );
+    return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationYesNo( title, message ) );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetYesNo( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
@@ -21,9 +20,9 @@ UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationW
     return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationYesNo( title, message ), custom_dialog_widget );
 }
 
-UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationOkCancel( UObject * InWorldContextObject, FText Title, FText Message )
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationOkCancel( UObject * in_world_context_object, FText title, FText message )
 {
-    return CreateAction( InWorldContextObject, UCommonGameDialogDescriptor::CreateConfirmationOkCancel( Title, Message ) );
+    return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationOkCancel( title, message ) );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetOkCancel( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
@@ -31,9 +30,9 @@ UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationW
     return CreateAction( in_world_context_object, UCommonGameDialogDescriptor::CreateConfirmationOkCancel( title, message ), custom_dialog_widget );
 }
 
-UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationCustom( UObject * InWorldContextObject, UCommonGameDialogDescriptor * Descriptor )
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationCustom( UObject * in_world_context_object, UCommonGameDialogDescriptor * descriptor )
 {
-    return CreateAction( InWorldContextObject, Descriptor );
+    return CreateAction( in_world_context_object, descriptor );
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetCustom( UObject * in_world_context_object, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
@@ -45,30 +44,30 @@ void UAsyncAction_ShowConfirmation::Activate()
 {
     if ( WorldContextObject && !TargetLocalPlayer )
     {
-        if ( UUserWidget * UserWidget = Cast< UUserWidget >( WorldContextObject ) )
+        if ( UUserWidget * user_widget = Cast< UUserWidget >( WorldContextObject ) )
         {
-            TargetLocalPlayer = UserWidget->GetOwningLocalPlayer< ULocalPlayer >();
+            TargetLocalPlayer = user_widget->GetOwningLocalPlayer< ULocalPlayer >();
         }
-        else if ( APlayerController * PC = Cast< APlayerController >( WorldContextObject ) )
+        else if ( APlayerController * player_controller = Cast< APlayerController >( WorldContextObject ) )
         {
-            TargetLocalPlayer = PC->GetLocalPlayer();
+            TargetLocalPlayer = player_controller->GetLocalPlayer();
         }
-        else if ( UWorld * World = WorldContextObject->GetWorld() )
+        else if ( UWorld * world = WorldContextObject->GetWorld() )
         {
-            if ( UGameInstance * GameInstance = World->GetGameInstance< UGameInstance >() )
+            if ( UGameInstance * game_instance = world->GetGameInstance< UGameInstance >() )
             {
-                TargetLocalPlayer = GameInstance->GetPrimaryPlayerController( false )->GetLocalPlayer();
+                TargetLocalPlayer = game_instance->GetPrimaryPlayerController( false )->GetLocalPlayer();
             }
         }
     }
 
     if ( TargetLocalPlayer )
     {
-        if ( UCommonMessagingSubsystem * Messaging = TargetLocalPlayer->GetSubsystem< UCommonMessagingSubsystem >() )
+        if ( auto * messaging = TargetLocalPlayer->GetSubsystem< UCommonMessagingSubsystem >() )
         {
-            FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate::CreateUObject( this, &UAsyncAction_ShowConfirmation::HandleConfirmationResult );
+            auto result_callback = FCommonMessagingResultDelegate::CreateUObject( this, &UAsyncAction_ShowConfirmation::HandleConfirmationResult );
 
-            Messaging->ShowConfirmation( Descriptor, CustomDialogWidget, ResultCallback );
+            messaging->ShowConfirmation( Descriptor, CustomDialogWidget, result_callback );
 
             return;
         }
@@ -78,16 +77,16 @@ void UAsyncAction_ShowConfirmation::Activate()
     HandleConfirmationResult( ECommonMessagingResult::Unknown );
 }
 
-void UAsyncAction_ShowConfirmation::HandleConfirmationResult( ECommonMessagingResult ConfirmationResult )
+void UAsyncAction_ShowConfirmation::HandleConfirmationResult( ECommonMessagingResult confirmation_result )
 {
-    OnResult.Broadcast( ConfirmationResult );
+    OnResult.Broadcast( confirmation_result );
 
     SetReadyToDestroy();
 }
 
 UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::CreateAction( UObject * in_world_context, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
 {
-    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
+    auto * action = NewObject< UAsyncAction_ShowConfirmation >();
     action->WorldContextObject = in_world_context;
     action->Descriptor = descriptor;
     action->CustomDialogWidget = custom_dialog_widget;

--- a/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
+++ b/Source/Private/Actions/AsyncAction_ShowConfirmation.cpp
@@ -6,83 +6,114 @@
 #include "Messaging/CommonGameDialog.h"
 #include "Messaging/CommonMessagingSubsystem.h"
 
-#include UE_INLINE_GENERATED_CPP_BY_NAME(AsyncAction_ShowConfirmation)
-
-UAsyncAction_ShowConfirmation::UAsyncAction_ShowConfirmation(const FObjectInitializer& ObjectInitializer)
-	: Super(ObjectInitializer)
+UAsyncAction_ShowConfirmation::UAsyncAction_ShowConfirmation( const FObjectInitializer & ObjectInitializer ) :
+    Super( ObjectInitializer )
 {
 }
 
-UAsyncAction_ShowConfirmation* UAsyncAction_ShowConfirmation::ShowConfirmationYesNo(UObject* InWorldContextObject, FText Title, FText Message)
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationYesNo( UObject * InWorldContextObject, FText Title, FText Message )
 {
-	UAsyncAction_ShowConfirmation* Action = NewObject<UAsyncAction_ShowConfirmation>();
-	Action->WorldContextObject = InWorldContextObject;
-	Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationYesNo(Title, Message);
-	Action->RegisterWithGameInstance(InWorldContextObject);
+    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
+    Action->WorldContextObject = InWorldContextObject;
+    Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationYesNo( Title, Message );
+    Action->RegisterWithGameInstance( InWorldContextObject );
 
-	return Action;
+    return Action;
 }
 
-UAsyncAction_ShowConfirmation* UAsyncAction_ShowConfirmation::ShowConfirmationOkCancel(UObject* InWorldContextObject, FText Title, FText Message)
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetYesNo( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
 {
-	UAsyncAction_ShowConfirmation* Action = NewObject<UAsyncAction_ShowConfirmation>();
-	Action->WorldContextObject = InWorldContextObject;
-	Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationOkCancel(Title, Message);
-	Action->RegisterWithGameInstance(InWorldContextObject);
+    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
+    action->WorldContextObject = in_world_context_object;
+    action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationYesNo( title, message );
+    action->RegisterWithGameInstance( in_world_context_object );
+    action->CustomDialogWidget = custom_dialog_widget;
 
-	return Action;
+    return action;
 }
 
-UAsyncAction_ShowConfirmation* UAsyncAction_ShowConfirmation::ShowConfirmationCustom(UObject* InWorldContextObject, UCommonGameDialogDescriptor* Descriptor)
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationOkCancel( UObject * InWorldContextObject, FText Title, FText Message )
 {
-	UAsyncAction_ShowConfirmation* Action = NewObject<UAsyncAction_ShowConfirmation>();
-	Action->WorldContextObject = InWorldContextObject;
-	Action->Descriptor = Descriptor;
-	Action->RegisterWithGameInstance(InWorldContextObject);
+    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
+    Action->WorldContextObject = InWorldContextObject;
+    Action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationOkCancel( Title, Message );
+    Action->RegisterWithGameInstance( InWorldContextObject );
 
-	return Action;
+    return Action;
+}
+
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetOkCancel( UObject * in_world_context_object, FText title, FText message, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
+{
+    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
+    action->WorldContextObject = in_world_context_object;
+    action->Descriptor = UCommonGameDialogDescriptor::CreateConfirmationOkCancel( title, message );
+    action->RegisterWithGameInstance( in_world_context_object );
+    action->CustomDialogWidget = custom_dialog_widget;
+
+    return action;
+}
+
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationCustom( UObject * InWorldContextObject, UCommonGameDialogDescriptor * Descriptor )
+{
+    UAsyncAction_ShowConfirmation * Action = NewObject< UAsyncAction_ShowConfirmation >();
+    Action->WorldContextObject = InWorldContextObject;
+    Action->Descriptor = Descriptor;
+    Action->RegisterWithGameInstance( InWorldContextObject );
+
+    return Action;
+}
+
+UAsyncAction_ShowConfirmation * UAsyncAction_ShowConfirmation::ShowConfirmationWithCustomWidgetCustom( UObject * in_world_context_object, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget )
+{
+    UAsyncAction_ShowConfirmation * action = NewObject< UAsyncAction_ShowConfirmation >();
+    action->WorldContextObject = in_world_context_object;
+    action->Descriptor = descriptor;
+    action->RegisterWithGameInstance( in_world_context_object );
+    action->CustomDialogWidget = custom_dialog_widget;
+
+    return action;
 }
 
 void UAsyncAction_ShowConfirmation::Activate()
 {
-	if (WorldContextObject && !TargetLocalPlayer)
-	{
-		if (UUserWidget* UserWidget = Cast<UUserWidget>(WorldContextObject))
-		{
-			TargetLocalPlayer = UserWidget->GetOwningLocalPlayer<ULocalPlayer>();
-		}
-		else if (APlayerController* PC = Cast<APlayerController>(WorldContextObject))
-		{
-			TargetLocalPlayer = PC->GetLocalPlayer();
-		}
-		else if (UWorld* World = WorldContextObject->GetWorld())
-		{
-			if (UGameInstance* GameInstance = World->GetGameInstance<UGameInstance>())
-			{
-				TargetLocalPlayer = GameInstance->GetPrimaryPlayerController(false)->GetLocalPlayer();
-			}
-		}
-	}
+    if ( WorldContextObject && !TargetLocalPlayer )
+    {
+        if ( UUserWidget * UserWidget = Cast< UUserWidget >( WorldContextObject ) )
+        {
+            TargetLocalPlayer = UserWidget->GetOwningLocalPlayer< ULocalPlayer >();
+        }
+        else if ( APlayerController * PC = Cast< APlayerController >( WorldContextObject ) )
+        {
+            TargetLocalPlayer = PC->GetLocalPlayer();
+        }
+        else if ( UWorld * World = WorldContextObject->GetWorld() )
+        {
+            if ( UGameInstance * GameInstance = World->GetGameInstance< UGameInstance >() )
+            {
+                TargetLocalPlayer = GameInstance->GetPrimaryPlayerController( false )->GetLocalPlayer();
+            }
+        }
+    }
 
-	if (TargetLocalPlayer)
-	{
-		if (UCommonMessagingSubsystem* Messaging = TargetLocalPlayer->GetSubsystem<UCommonMessagingSubsystem>())
-		{
-			FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate::CreateUObject(this, &UAsyncAction_ShowConfirmation::HandleConfirmationResult);
-			Messaging->ShowConfirmation(Descriptor, ResultCallback);
-			return;
-		}
-	}
-	
-	// If we couldn't make the confirmation, just handle an unknown result and broadcast nothing
-	HandleConfirmationResult(ECommonMessagingResult::Unknown);
+    if ( TargetLocalPlayer )
+    {
+        if ( UCommonMessagingSubsystem * Messaging = TargetLocalPlayer->GetSubsystem< UCommonMessagingSubsystem >() )
+        {
+            FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate::CreateUObject( this, &UAsyncAction_ShowConfirmation::HandleConfirmationResult );
+
+            Messaging->ShowConfirmation( Descriptor, CustomDialogWidget, ResultCallback );
+
+            return;
+        }
+    }
+
+    // If we couldn't make the confirmation, just handle an unknown result and broadcast nothing
+    HandleConfirmationResult( ECommonMessagingResult::Unknown );
 }
 
-void UAsyncAction_ShowConfirmation::HandleConfirmationResult(ECommonMessagingResult ConfirmationResult)
+void UAsyncAction_ShowConfirmation::HandleConfirmationResult( ECommonMessagingResult ConfirmationResult )
 {
-	OnResult.Broadcast(ConfirmationResult);
+    OnResult.Broadcast( ConfirmationResult );
 
-	SetReadyToDestroy();
+    SetReadyToDestroy();
 }
-
-

--- a/Source/Private/Messaging/CommonMessagingSubsystem.cpp
+++ b/Source/Private/Messaging/CommonMessagingSubsystem.cpp
@@ -1,46 +1,42 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #include "Messaging/CommonMessagingSubsystem.h"
 
-#include "Engine/GameInstance.h"
-#include "Engine/LocalPlayer.h"
-#include "UObject/UObjectHash.h"
+#include "Messaging/CommonGameDialog.h"
 
-#include UE_INLINE_GENERATED_CPP_BY_NAME(CommonMessagingSubsystem)
+#include <Engine/GameInstance.h>
+#include <Engine/LocalPlayer.h>
+#include <UObject/UObjectHash.h>
 
 class FSubsystemCollectionBase;
 class UClass;
 
-void UCommonMessagingSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+void UCommonMessagingSubsystem::Initialize( FSubsystemCollectionBase & Collection )
 {
-	Super::Initialize(Collection);
+    Super::Initialize( Collection );
 }
 
 void UCommonMessagingSubsystem::Deinitialize()
 {
-	Super::Deinitialize();
+    Super::Deinitialize();
 }
 
-bool UCommonMessagingSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+bool UCommonMessagingSubsystem::ShouldCreateSubsystem( UObject * Outer ) const
 {
-	if (!CastChecked<ULocalPlayer>(Outer)->GetGameInstance()->IsDedicatedServerInstance())
-	{
-		TArray<UClass*> ChildClasses;
-		GetDerivedClasses(GetClass(), ChildClasses, false);
+    if ( !CastChecked< ULocalPlayer >( Outer )->GetGameInstance()->IsDedicatedServerInstance() )
+    {
+        TArray< UClass * > ChildClasses;
+        GetDerivedClasses( GetClass(), ChildClasses, false );
 
-		// Only create an instance if there is no override implementation defined elsewhere
-		return ChildClasses.Num() == 0;
-	}
+        // Only create an instance if there is no override implementation defined elsewhere
+        return ChildClasses.Num() == 0;
+    }
 
-	return false;
+    return false;
 }
 
-void UCommonMessagingSubsystem::ShowConfirmation(UCommonGameDialogDescriptor* DialogDescriptor, FCommonMessagingResultDelegate ResultCallback)
+void UCommonMessagingSubsystem::ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget, FCommonMessagingResultDelegate result_callback )
 {
-	
 }
 
-void UCommonMessagingSubsystem::ShowError(UCommonGameDialogDescriptor* DialogDescriptor, FCommonMessagingResultDelegate ResultCallback)
+void UCommonMessagingSubsystem::ShowError( UCommonGameDialogDescriptor * DialogDescriptor, FCommonMessagingResultDelegate ResultCallback )
 {
-	
 }

--- a/Source/Private/Messaging/CommonMessagingSubsystem.cpp
+++ b/Source/Private/Messaging/CommonMessagingSubsystem.cpp
@@ -1,13 +1,12 @@
 #include "Messaging/CommonMessagingSubsystem.h"
 
-#include "Messaging/CommonGameDialog.h"
-
 #include <Engine/GameInstance.h>
 #include <Engine/LocalPlayer.h>
 #include <UObject/UObjectHash.h>
 
 class FSubsystemCollectionBase;
 class UClass;
+class UCommonGameDialog;
 
 void UCommonMessagingSubsystem::Initialize( FSubsystemCollectionBase & Collection )
 {

--- a/Source/Public/Actions/AsyncAction_ShowConfirmation.h
+++ b/Source/Public/Actions/AsyncAction_ShowConfirmation.h
@@ -10,8 +10,9 @@
 enum class ECommonMessagingResult : uint8;
 
 class FText;
-class UCommonGameDialogDescriptor;
 class ULocalPlayer;
+class UCommonGameDialog;
+class UCommonGameDialogDescriptor;
 struct FFrame;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam( FCommonMessagingResultMCDelegate, ECommonMessagingResult, Result );
@@ -70,6 +71,7 @@ public:
 
 private:
     void HandleConfirmationResult( ECommonMessagingResult ConfirmationResult );
+    static UAsyncAction_ShowConfirmation * CreateAction( UObject * in_world_context, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget = nullptr );
 
     UPROPERTY( Transient )
     TObjectPtr< UObject > WorldContextObject;

--- a/Source/Public/Actions/AsyncAction_ShowConfirmation.h
+++ b/Source/Public/Actions/AsyncAction_ShowConfirmation.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "Kismet/BlueprintAsyncActionBase.h"
-
 #include "UObject/ObjectPtr.h"
+
 #include "AsyncAction_ShowConfirmation.generated.h"
 
 enum class ECommonMessagingResult : uint8;
@@ -14,47 +14,72 @@ class UCommonGameDialogDescriptor;
 class ULocalPlayer;
 struct FFrame;
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FCommonMessagingResultMCDelegate, ECommonMessagingResult, Result);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam( FCommonMessagingResultMCDelegate, ECommonMessagingResult, Result );
 
 /**
  * Allows easily triggering an async confirmation dialog in blueprints that you can then wait on the result.
  */
 UCLASS()
-class UAsyncAction_ShowConfirmation : public UBlueprintAsyncActionBase
+class COMMONGAME_API UAsyncAction_ShowConfirmation : public UBlueprintAsyncActionBase
 {
-	GENERATED_UCLASS_BODY()
+    GENERATED_UCLASS_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable, BlueprintCosmetic, meta = (BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject"))
-	static UAsyncAction_ShowConfirmation* ShowConfirmationYesNo(
-		UObject* InWorldContextObject, FText Title, FText Message
-	);
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationYesNo(
+        UObject * InWorldContextObject,
+        FText Title,
+        FText Message );
 
-	UFUNCTION(BlueprintCallable, BlueprintCosmetic, meta = (BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject"))
-	static UAsyncAction_ShowConfirmation* ShowConfirmationOkCancel(
-		UObject* InWorldContextObject, FText Title, FText Message
-	);
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationOkCancel(
+        UObject * InWorldContextObject,
+        FText Title,
+        FText Message );
 
-	UFUNCTION(BlueprintCallable, BlueprintCosmetic, meta = (BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject"))
-	static UAsyncAction_ShowConfirmation* ShowConfirmationCustom(
-		UObject* InWorldContextObject, UCommonGameDialogDescriptor* Descriptor
-	);
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationCustom(
+        UObject * InWorldContextObject,
+        UCommonGameDialogDescriptor * Descriptor );
 
-	virtual void Activate() override;
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationWithCustomWidgetYesNo(
+        UObject * in_world_context_object,
+        FText title,
+        FText message,
+        TSubclassOf< UCommonGameDialog > custom_dialog_widget );
+
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationWithCustomWidgetOkCancel(
+        UObject * in_world_context_object,
+        FText title,
+        FText message,
+        TSubclassOf< UCommonGameDialog > custom_dialog_widget );
+
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
+    static UAsyncAction_ShowConfirmation * ShowConfirmationWithCustomWidgetCustom(
+        UObject * in_world_context_object,
+        UCommonGameDialogDescriptor * descriptor,
+        TSubclassOf< UCommonGameDialog > custom_dialog_widget );
+
+    virtual void Activate() override;
 
 public:
-	UPROPERTY(BlueprintAssignable)
-	FCommonMessagingResultMCDelegate OnResult;
+    UPROPERTY( BlueprintAssignable )
+    FCommonMessagingResultMCDelegate OnResult;
 
 private:
-	void HandleConfirmationResult(ECommonMessagingResult ConfirmationResult);
+    void HandleConfirmationResult( ECommonMessagingResult ConfirmationResult );
 
-	UPROPERTY(Transient)
-	TObjectPtr<UObject> WorldContextObject;
+    UPROPERTY( Transient )
+    TObjectPtr< UObject > WorldContextObject;
 
-	UPROPERTY(Transient)
-	TObjectPtr<ULocalPlayer> TargetLocalPlayer;
+    UPROPERTY( Transient )
+    TObjectPtr< ULocalPlayer > TargetLocalPlayer;
 
-	UPROPERTY(Transient)
-	TObjectPtr<UCommonGameDialogDescriptor> Descriptor;
+    UPROPERTY( Transient )
+    TObjectPtr< UCommonGameDialogDescriptor > Descriptor;
+
+    UPROPERTY( Transient )
+    TSubclassOf< UCommonGameDialog > CustomDialogWidget;
 };

--- a/Source/Public/Actions/AsyncAction_ShowConfirmation.h
+++ b/Source/Public/Actions/AsyncAction_ShowConfirmation.h
@@ -1,9 +1,7 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #pragma once
 
-#include "Kismet/BlueprintAsyncActionBase.h"
-#include "UObject/ObjectPtr.h"
+#include <Kismet/BlueprintAsyncActionBase.h>
+#include <UObject/ObjectPtr.h>
 
 #include "AsyncAction_ShowConfirmation.generated.h"
 
@@ -26,22 +24,22 @@ class COMMONGAME_API UAsyncAction_ShowConfirmation : public UBlueprintAsyncActio
     GENERATED_UCLASS_BODY()
 
 public:
-    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
     static UAsyncAction_ShowConfirmation * ShowConfirmationYesNo(
-        UObject * InWorldContextObject,
-        FText Title,
-        FText Message );
+        UObject * in_world_context_object,
+        FText title,
+        FText message );
 
-    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
     static UAsyncAction_ShowConfirmation * ShowConfirmationOkCancel(
-        UObject * InWorldContextObject,
-        FText Title,
-        FText Message );
+        UObject * in_world_context_object,
+        FText title,
+        FText message );
 
-    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "InWorldContextObject" ) )
+    UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
     static UAsyncAction_ShowConfirmation * ShowConfirmationCustom(
-        UObject * InWorldContextObject,
-        UCommonGameDialogDescriptor * Descriptor );
+        UObject * in_world_context_object,
+        UCommonGameDialogDescriptor * descriptor );
 
     UFUNCTION( BlueprintCallable, BlueprintCosmetic, meta = ( BlueprintInternalUseOnly = "true", WorldContext = "in_world_context_object" ) )
     static UAsyncAction_ShowConfirmation * ShowConfirmationWithCustomWidgetYesNo(
@@ -70,7 +68,7 @@ public:
     FCommonMessagingResultMCDelegate OnResult;
 
 private:
-    void HandleConfirmationResult( ECommonMessagingResult ConfirmationResult );
+    void HandleConfirmationResult( ECommonMessagingResult confirmation_result );
     static UAsyncAction_ShowConfirmation * CreateAction( UObject * in_world_context, UCommonGameDialogDescriptor * descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget = nullptr );
 
     UPROPERTY( Transient )

--- a/Source/Public/Messaging/CommonMessagingSubsystem.h
+++ b/Source/Public/Messaging/CommonMessagingSubsystem.h
@@ -1,50 +1,47 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #pragma once
 
-#include "Subsystems/LocalPlayerSubsystem.h"
+#include <Subsystems/LocalPlayerSubsystem.h>
 
 #include "CommonMessagingSubsystem.generated.h"
 
+class UCommonGameDialog;
 class FSubsystemCollectionBase;
 class UCommonGameDialogDescriptor;
 class UObject;
 
 /** Possible results from a dialog */
-UENUM(BlueprintType)
+UENUM( BlueprintType )
 enum class ECommonMessagingResult : uint8
 {
-	/** The "yes" button was pressed */
-	Confirmed,
-	/** The "no" button was pressed */
-	Declined,
-	/** The "ignore/cancel" button was pressed */
-	Cancelled,
-	/** The dialog was explicitly killed (no user input) */
-	Killed,
-	Unknown UMETA(Hidden)
+    /** The "yes" button was pressed */
+    Confirmed,
+    /** The "no" button was pressed */
+    Declined,
+    /** The "ignore/cancel" button was pressed */
+    Cancelled,
+    /** The dialog was explicitly killed (no user input) */
+    Killed,
+    Unknown UMETA( Hidden )
 };
 
-DECLARE_DELEGATE_OneParam(FCommonMessagingResultDelegate, ECommonMessagingResult /* Result */);
+DECLARE_DELEGATE_OneParam( FCommonMessagingResultDelegate, ECommonMessagingResult /* Result */ );
 
 /**
- * 
+ *
  */
-UCLASS(config = Game)
+UCLASS( config = Game )
 class COMMONGAME_API UCommonMessagingSubsystem : public ULocalPlayerSubsystem
 {
-	GENERATED_BODY()
+    GENERATED_BODY()
 
 public:
-	UCommonMessagingSubsystem() { }
+    UCommonMessagingSubsystem()
+    {}
 
-	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
-	virtual void Deinitialize() override;
-	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+    void Initialize( FSubsystemCollectionBase & Collection ) override;
+    void Deinitialize() override;
+    bool ShouldCreateSubsystem( UObject * Outer ) const override;
 
-	virtual void ShowConfirmation(UCommonGameDialogDescriptor* DialogDescriptor, FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate());
-	virtual void ShowError(UCommonGameDialogDescriptor* DialogDescriptor, FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate());
-
-private:
-
+    virtual void ShowConfirmation( UCommonGameDialogDescriptor * dialog_descriptor, TSubclassOf< UCommonGameDialog > custom_dialog_widget = nullptr, FCommonMessagingResultDelegate result_callback = FCommonMessagingResultDelegate() );
+    virtual void ShowError( UCommonGameDialogDescriptor * DialogDescriptor, FCommonMessagingResultDelegate ResultCallback = FCommonMessagingResultDelegate() );
 };


### PR DESCRIPTION
please check https://github.com/TheEmidee/UEGameBaseFramework/pull/243 for the entire feature

Add the possibility to use specific widget instead of the common one for confirmation dialogs.

I've chosen to modify the existing methods instead of creating overloads because at the end. It was resulting that in `UAsyncAction_ShowConfirmation::Activate()` I had to check if `CustomDialogWidget` is nullptr or not to call the old or the new `ShowConfirmation()` method ( for the olds node still working). 
And since calling the old method, called the new one with the Common widget as parameter, I m thinking that this way the code is more readable and understandable avoiding overloads

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TheEmidee/UECommonGame/1)
<!-- Reviewable:end -->
